### PR TITLE
Convert to use recursive lookups for services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 VERSION := $(shell git describe --tags --always --dirty="-dev")
 LDFLAGS := -ldflags='-X "main.Version=$(VERSION)"'
 
+build: deps
+	go build -o ./dist/chamber
+
+deps: govendor
+	@govendor sync
+
 release: gh-release clean dist
 	govendor sync
 	github-release release \
@@ -35,7 +41,7 @@ dist:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(LDFLAGS) -o dist/chamber-$(VERSION)-linux-amd64
 
 gh-release:
-	go get -u github.com/aktau/github-release
+	@which github-release >/dev/null || go get -u github.com/aktau/github-release
 
 govendor:
-	go get -u github.com/kardianos/govendor
+	@which govendor >/dev/null || go get -u github.com/kardianos/govendor

--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,14 @@ release: gh-release clean dist
 	govendor sync
 	github-release release \
 	--security-token $$GH_LOGIN \
-	--user segmentio \
+	--user saganbot \
 	--repo chamber \
 	--tag $(VERSION) \
 	--name $(VERSION)
 
 	github-release upload \
 	--security-token $$GH_LOGIN \
-	--user segmentio \
+	--user saganbot \
 	--repo chamber \
 	--tag $(VERSION) \
 	--name chamber-$(VERSION)-darwin-amd64 \
@@ -26,7 +26,7 @@ release: gh-release clean dist
 
 	github-release upload \
 	--security-token $$GH_LOGIN \
-	--user segmentio \
+	--user saganbot \
 	--repo chamber \
 	--tag $(VERSION) \
 	--name chamber-$(VERSION)-linux-amd64 \

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -22,9 +22,6 @@ func init() {
 
 func delete(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
-	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
-	}
 
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -41,10 +41,6 @@ func execRun(cmd *cobra.Command, args []string) error {
 	env := environ(os.Environ())
 	secretStore := store.NewSSMStore(numRetries)
 	for _, service := range services {
-		if err := validateService(service); err != nil {
-			return errors.Wrap(err, "Failed to validate service")
-		}
-
 		rawSecrets, err := secretStore.ListRaw(strings.ToLower(service))
 		if err != nil {
 			return errors.Wrap(err, "Failed to list store contents")

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -41,10 +41,6 @@ func runExport(cmd *cobra.Command, args []string) error {
 	secretStore := store.NewSSMStore(numRetries)
 	params := make(map[string]string)
 	for _, service := range args {
-		if err := validateService(service); err != nil {
-			return errors.Wrapf(err, "Failed to validate service %s", service)
-		}
-
 		rawSecrets, err := secretStore.ListRaw(strings.ToLower(service))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to list store contents for service %s", service)

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -25,10 +25,6 @@ func init() {
 
 func history(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
-	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
-	}
-
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -27,9 +27,6 @@ func init() {
 
 func importRun(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
-	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
-	}
 
 	var in io.Reader
 	var err error

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -30,10 +30,6 @@ func init() {
 
 func list(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
-	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
-	}
-
 	secretStore := store.NewSSMStore(numRetries)
 	secrets, err := secretStore.List(service, withValues)
 	if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -64,11 +64,11 @@ func key(s string) string {
 	_, noPaths := os.LookupEnv("CHAMBER_NO_PATHS")
 	if !noPaths {
 		tokens := strings.Split(s, "/")
-		secretKey := tokens[2]
+		secretKey := tokens[len(tokens)-1]
 		return secretKey
 	}
 
 	tokens := strings.Split(s, ".")
-	secretKey := tokens[1]
+	secretKey := tokens[len(tokens)-1]
 	return secretKey
 }

--- a/cmd/read.go
+++ b/cmd/read.go
@@ -32,10 +32,6 @@ func init() {
 
 func read(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
-	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
-	}
-
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,13 +49,6 @@ func Execute(vers string) {
 	}
 }
 
-func validateService(service string) error {
-	if !validServiceFormat.MatchString(service) {
-		return fmt.Errorf("Failed to validate service name '%s'.  Only alphanumeric, dashes, and underscores are allowed for service names", service)
-	}
-	return nil
-}
-
 func validateKey(key string) error {
 	if !validKeyFormat.MatchString(key) {
 		return fmt.Errorf("Failed to validate key name '%s'.  Only alphanumeric, dashes, and underscores are allowed for key names", key)

--- a/cmd/write.go
+++ b/cmd/write.go
@@ -30,10 +30,6 @@ func init() {
 
 func write(cmd *cobra.Command, args []string) error {
 	service := strings.ToLower(args[0])
-	if err := validateService(service); err != nil {
-		return errors.Wrap(err, "Failed to validate service")
-	}
-
 	key := strings.ToLower(args[1])
 	if err := validateKey(key); err != nil {
 		return errors.Wrap(err, "Failed to validate key")


### PR DESCRIPTION
## What
- Improve the `Makefile` for Gladly support
- Remove restricting the service names to a certain style
- Display last in the path instead of the second element
- Always use recursive lookups for keys

## Why
So we can leverage chamber for Gladly!

## Who
@mkj28 
