### PR TITLE
Use raw service name if CLUSTER not provided

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,10 @@ func validateKey(key string) error {
 func gladlyService(service string) string {
 	// format of cluster is master.gladly.qa or production1.gladly.com
 	cluster := os.Getenv("CLUSTER")
+	if cluster == "" {
+		return strings.ToLower(service)
+	}
+
 	envIndex := strings.Index(cluster, ".")
 	environment := cluster[:envIndex]
 	namespace := cluster[envIndex+1:]


### PR DESCRIPTION
## What
Return the lowercase service name if `CLUSTER` not provided

## Why
So we can still use `write` functionality of `chamber` for services not running in a cluster (i.e. Lambdas) 

## Who
@darend @mkj28 