### PR TITLE
add exponential backoff for NoCredentialProviders error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV PROJECT_DIR=$GOPATH/src/github.com/segmentio/chamber
 WORKDIR $PROJECT_DIR
 
 COPY . .
+RUN go get
 
 # ensure linux binaries are compatible
 RUN CGO_ENABLED=0 make build

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -43,7 +43,7 @@ func execRun(cmd *cobra.Command, args []string) error {
 	if isRunningInCluster() {
 		secretStore := store.NewSSMStore(numRetries)
 		for _, service := range services {
-			rawSecrets, err := secretStore.ListRaw(gladlyService(service))
+			rawSecrets, err := ListRaw(secretStore, gladlyService(service))
 			if err != nil {
 				return errors.Wrap(err, "Failed to list store contents")
 			}

--- a/cmd/gladly_secrets_list.go
+++ b/cmd/gladly_secrets_list.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/cenkalti/backoff"
+	chamberstore "github.com/segmentio/chamber/store"
+)
+
+type listSecretsOperation struct {
+	service     string
+	secretStore *chamberstore.SSMStore
+	rawSecrets  *[]chamberstore.RawSecret
+}
+
+func (op *listSecretsOperation) listSecrets() error {
+	rawSecrets, err := op.secretStore.ListRaw(op.service)
+
+	if err == nil {
+		fmt.Println("chamber: read some secrets: ", len(rawSecrets))
+		*op.rawSecrets = rawSecrets
+		return nil
+	}
+
+	// if it's not an AWS error - return a permanent error
+	awsErr, isAwserr := err.(awserr.Error)
+	if !isAwserr {
+		fmt.Println("chamber: gladly_secrets_list: got permanent error: ", err)
+		return backoff.Permanent(err)
+	}
+
+	// if it's an AWS error but not the one we're expecting -
+	// return a permanent error
+	if awsErr.Code() != "NoCredentialProviders" || !strings.Contains(awsErr.Message(), "no valid providers in chain") {
+		fmt.Println("chamber: gladly_secrets_list: got permanent error from AWS: ", err)
+		return backoff.Permanent(err)
+	}
+
+	fmt.Println("chamber: gladly_secrets_list: encountered retryable error: ", err)
+	// we got the NoCredentialProviders error that may indicate the race condition issue
+	// return the error as non-permanent for possible retry
+	return err
+}
+
+func ListRaw(secretStore *chamberstore.SSMStore, service string) ([]chamberstore.RawSecret, error) {
+	rawSecrets := []chamberstore.RawSecret{}
+
+	operation := listSecretsOperation{
+		secretStore: secretStore,
+		service:     service,
+		rawSecrets:  &rawSecrets,
+	}
+
+	if err := backoff.Retry(operation.listSecrets, backoff.NewExponentialBackOff()); err != nil {
+		return nil, err
+	}
+
+	return *operation.rawSecrets, nil
+}

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"time"
-
 	"github.com/segmentio/chamber/cmd"
 )
 
@@ -12,6 +10,5 @@ var (
 )
 
 func main() {
-	time.Sleep(5 * time.Second)
 	cmd.Execute(Version)
 }


### PR DESCRIPTION
[ch18350]

##### WHAT

add exponential backoff/retry logic to chamber

##### WHY

chamber occasionally fails during secrets enumeration with an error like

```
NoCredentialProviders: no valid providers in chain. Deprecated.
```

this is a race condition with kiam - this patch works around it with backoff/retry

##### EXAMPLE - with retry

```
[master] bastion/1 (root) ~ # kv logs users-test-report-ihkswxizcdvtxg1iwvmt9q-20180828000747-2101867412 main

main(): christest - startup - executing command
ListRaw(): created operation with service:  clusters/gladly.qa/master/vortex-data-extractor

listSecretsOperation.listSecrets(): op.service:  clusters/gladly.qa/master/vortex-data-extractor
chamber: gladly_secrets_list: encountered retryable error:  NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors

listSecretsOperation.listSecrets(): op.service:  clusters/gladly.qa/master/vortex-data-extractor
chamber: gladly_secrets_list: exiting with success
read some secrets:  0
ListRaw(): returning some secrets with success, number is secrets to be returned:  0
ListRaw(): created operation with service:  clusters/gladly.qa/master/vortex-runner
listSecretsOperation.listSecrets(): op.service:  clusters/gladly.qa/master/vortex-runner
chamber: gladly_secrets_list: exiting with success
read some secrets:  2
ListRaw(): returning some secrets with success, number is secrets to be returned:  2
ListRaw(): created operation with service:  clusters/gladly.qa/master/custom-reporting
listSecretsOperation.listSecrets(): op.service:  clusters/gladly.qa/master/custom-reporting
chamber: gladly_secrets_list: exiting with success
read some secrets:  1
ListRaw(): returning some secrets with success, number is secrets to be returned:  1

{"severity": "debug", "message": "starting data extraction", "meta": {"name": "users-test-report-ihkswxizcdvtxg1iwvmt9q-20180828000747", "type": "custom-reporting,", "timestamp": "20180828000747", "user": "custom-reporting", "orgId": "ihKsWxiZCDVtXg1iwVmT9Q", "task": "data-extractor", "reportType": "users-test-report"}}
{"severity": "debug", "message": "data extraction completed in 161ms", "meta": {"name": "users-test-report-ihkswxizcdvtxg1iwvmt9q-20180828000747", "type": "custom-reporting,", "timestamp": "20180828000747", "user": "custom-reporting", "orgId": "ihKsWxiZCDVtXg1iwVmT9Q", "task": "data-extractor", "reportType": "users-test-report"}}

[master] bastion/1 (root) ~ #  
```
